### PR TITLE
Increase retry count of calling google-tts-api

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,9 +112,10 @@ async function main() {
   }
 
   // get URL for TTS
+  console.debug(`Calling googleTTS (retryCount = ${program.ttsRetryCount})`);
   const url = await retry(function() {
     return googleTTS(text, program.language, program.speed);
-  }, 2, 3000).catch((err) => {
+  }, 10, 1000).catch((err) => {
     console.error('error: failed to get a URL for Google Text-to-Speech:', err);
     process.exit(1);
   });


### PR DESCRIPTION
In my environment, I am experiencing following errors too often (more than 2 times).
```
Error: get key failed from google
    at /Users/hikalium/repo/google-home-say/node_modules/google-tts-api/lib/key.js:30:32
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async main (/Users/hikalium/repo/google-home-say/index.js:117:15)
```

According to [this issue](https://github.com/zlargon/google-tts/issues/33), the workaround is just retrying more and it solves the problem in my case. So, I think adding `--tts-retry-count` is a good idea to mitigate this problem. Also, this change increase the default number of retry to 4 to avoid seeing this error by default.